### PR TITLE
Add vscode files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ src/main/resources/docs/
 /out/
 /*.iml
 
+# VSCode files
+.vscode/*
+
 # Storage/log files
 /data/
 /config.json


### PR DESCRIPTION
Prevent vscode config files from being pushed to our team repo.