### PR TITLE
Reordered use cases for MVP and fixed format

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -318,7 +318,27 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 (For all use cases below, the **System** is the `HeartLink` and the **Actor** is the `user`, unless specified otherwise)
 
-**Use case: Add a client**
+**<a id="use-case-view-clients"></a>U1: View clients**
+
+**MSS**
+1. User requests to list of clients.
+2. User provides additional attributes to filter by, such as name, appointment date, tag, and rank.
+3. HeartLink displays the list of all clients corresponding to the attributes given by a user.
+   All information for each person are shown.
+
+   Use case ends.
+
+**Extensions**
+* 2a. The given request is syntactically incorrect.
+    * 2a1. HeartLink shows an error message.
+
+      Use case resumes at step 1.
+* 2b. One of the fields are invalid.
+    * 2b1. HearLink shows an error message.
+
+      Use case resumes at step 1.
+
+**U2: Add a client**
 
 **MSS**
 
@@ -347,12 +367,34 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case ends.
 
-
-**Use case: Edit client information**
+**U3: Delete client**
 
 **MSS**
 
-1.  User requests to [<u>view clients</u>](#use-case-view-clients). 
+1.  User requests to [<u>U1 View clients</u>](#use-case-view-clients).
+2.  HeartLink shows a list of clients
+3.  User requests to delete a specific person in the list by name
+4.  HeartLink deletes the specified client from the address book.
+
+    Use case ends.
+
+**Extensions**
+
+* 2a. The list is empty.
+
+  Use case ends.
+
+* 3a. The given name does not exist.
+
+    * 3a1. HeartLink shows an error message.
+
+      Use case resumes at step 2.
+
+**U4: Edit client information**
+
+**MSS**
+
+1.  User requests to [<u>U1 View clients</u>](#use-case-view-clients). 
 2.  HeartLink shows a list of clients
 3.  User requests to edit a specific person in the list
 4.  HeartLink edits the specified details of the clients.
@@ -383,11 +425,11 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case resumes at step 2.
 
-**Use Case: Link Appointment to Client**
+**U5: Link Appointment to Client**
 
 **MSS**
 
-1. User requests to [<u>view clients</u>](#use-case-view-clients).
+1. User requests to [<u>U1 View clients</u>](#use-case-view-clients).
 2. HeartLink shows a list of clients.
 3. User requests to link an appointment to a specific client with the relevant details.
 4. HeartLink creates the appointment and links it to the chosen client.
@@ -420,49 +462,6 @@ Use case ends.
   * 3d1. HeartLink shows a duplicate appointment error.
 
     Use case resumes at step 2.
-
-**<a id="use-case-view-clients"></a>Use case: View clients**
-
-**MSS**
-1. User requests to list of clients.
-2. User provides additional attributes to filter by, such as name, appointment date, tag, and rank.
-3. HeartLink displays the list of all clients corresponding to the attributes given by a user.
-All information for each person are shown.
-
-   Use case ends.
-
-**Extensions**
-* 2a. The given request is syntactically incorrect.
-  * 2a1. HeartLink shows an error message.
-    
-    Use case resumes at step 1.
-* 2b. One of the fields are invalid. 
-  * 2b1. HearLink shows an error message.
-    
-    Use case resumes at step 1.
-
-**Use case: Delete client**
-
-**MSS**
-
-1.  User requests to [<u>view clients</u>](#use-case-view-clients). 
-2.  HeartLink shows a list of clients
-3.  User requests to delete a specific person in the list by name
-4.  HeartLink deletes the specified client from the address book.
-
-    Use case ends.
-
-**Extensions**
-
-* 2a. The list is empty.
-
-  Use case ends.
-
-* 3a. The given name does not exist.
-
-    * 3a1. HeartLink shows an error message.
-
-      Use case resumes at step 2.
 
 ### Non-Functional Requirements
 


### PR DESCRIPTION
- Reordered the use cases such that they make sense (view -> add -> delete -> edit -> link appointment)
- Gave each use case a id number (U1 to U5) and changed the hyperlink text accordingly (U1 View clients)

Fixes #61