### PR TITLE
Add support for view command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -110,24 +110,47 @@ Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
 *  `edit 2 n/Betsy Crower t/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
 
-### Locating persons by name: `find`
+### Look up clients by fields: `find`
 
-Finds persons whose names contain any of the given keywords.
+```
+find [n/KEYWORD_1 KEYWORD_2 ...] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG] [r/RANK]
+```
+You can use this command to retrieve a list of clients that match the specified attributes:
+- Name `n/KEYWORD_1 KEYWORD_2 ...` — lists all clients whose names contain any of the specified keywords.
+The search is case-insensitive.
+- Phone number `p/PHONE` - lists all clients whose phone numbers exactly match `PHONE`.
+- Email `e/EMAIL` - lists all clients whose email exactly match `EMAIL`.
+- Address `r/ADDRESS` - lists all clients whose address exactly match `ADDRESS`.
+- Tag `t/TAG` - lists all clients whose tag contains `TAG`.
+- Address `r/ADDRESS` - lists all clients whose rank exactly match `RANK`.
 
-Format: `find KEYWORD [MORE_KEYWORDS]`
+> [!NOTE]  
+> The order of the attributes does not matter.
+> If you haven't specified any attributes, the system will list all clients.
 
-* The search is case-insensitive. e.g `hans` will match `Hans`
-* The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
-* Only the name is searched.
-* Only full words will be matched e.g. `Han` will not match `Hans`
-* Persons matching at least one keyword will be returned (i.e. `OR` search).
-  e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
 
-Examples:
-* `find John` returns `john` and `John Doe`
-* `find alex david` returns `Alex Yeoh`, `David Li`<br>
-  ![result for 'find alex david'](images/findAlexDavidResult.png)
+Example usage:
 
+You want to list all urgent clients whose name contains "John" or "Doe.
+```
+find /n John Doe /r urgent
+```
+Example output (other fields omitted)
+```
+John Doe [rank: urgent]
+Jane Doe [rank: urgent]
+John Lock [rank: urgent]
+```
+
+You want to list all clients with tag patients and phone number 81234567.
+```
+find /p 81234567 /t patient
+```
+Example output (other fields omitted)
+```
+James Bond [81234567, tag: patient, friend]
+John Doe [81234567, tag: patient]
+```
 ### Deleting a person : `delete`
 
 Deletes the specified person from the address book.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -113,16 +113,16 @@ Examples:
 ### Look up clients by fields: `find`
 
 ```
-find [n/KEYWORD_1 KEYWORD_2 ...] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG] [r/RANK]
+find [/n KEYWORD_1 KEYWORD_2 ...] [/p PHONE] [/e EMAIL] [/a ADDRESS] [/t TAG] [/r RANK]
 ```
 You can use this command to retrieve a list of clients that match the specified attributes:
-- Name `n/KEYWORD_1 KEYWORD_2 ...` — lists all clients whose names contain any of the specified keywords.
+- Name `/n KEYWORD_1 KEYWORD_2 ...` — lists all clients whose names contain any of the specified keywords.
 The search is case-insensitive.
-- Phone number `p/PHONE` - lists all clients whose phone numbers exactly match `PHONE`.
-- Email `e/EMAIL` - lists all clients whose email exactly match `EMAIL`.
-- Address `r/ADDRESS` - lists all clients whose address exactly match `ADDRESS`.
-- Tag `t/TAG` - lists all clients whose tag contains `TAG`.
-- Address `r/ADDRESS` - lists all clients whose rank exactly match `RANK`.
+- Phone number `/p PHONE` - lists all clients whose phone numbers exactly match `PHONE`.
+- Email `/e EMAIL` - lists all clients whose email exactly match `EMAIL`.
+- Address `/r ADDRESS` - lists all clients whose address exactly match `ADDRESS`.
+- Tag `/t TAG` - lists all clients whose tag contains `TAG`.
+- Address `/r ADDRESS` - lists all clients whose rank exactly match `RANK`.
 
 > [!NOTE]  
 > The order of the attributes does not matter.

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,6 +1,12 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RANK;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -13,7 +19,18 @@ import seedu.address.model.person.PersonQuery;
  */
 public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
-    public static final String MESSAGE_USAGE = "<TO BE ADDED>";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds persons whose fields"
+        + " contain any of the given keywords.\n"
+        + "Parameters: "
+        + "[" + PREFIX_NAME + "NAME] "
+        + "[" + PREFIX_PHONE + "PHONE] "
+        + "[" + PREFIX_EMAIL + "EMAIL] "
+        + "[" + PREFIX_ADDRESS + "ADDRESS] "
+        + "[" + PREFIX_TAG + "TAG]..."
+        + "[" + PREFIX_RANK + "RANK]\n"
+        + "Example: " + COMMAND_WORD + " "
+        + PREFIX_PHONE + "91234567 "
+        + PREFIX_EMAIL + "johndoe@example.com";
 
     private final PersonQuery query;
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -4,13 +4,34 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonQuery;
+
+public class FindCommand extends Command {
+    public static final String COMMAND_WORD = "find";
+    public static final String MESSAGE_USAGE = "<TO BE ADDED>";
+    public static final String MESSAGE_SUCCESS = "<TO BE ADDED>";
+
+    private final PersonQuery query;
+
+    public FindCommand(PersonQuery query) {
+        requireNonNull(query);
+        this.query = query;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        model.updateFilteredPersonList(query::filter);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}
+
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
- * Keyword matching is case insensitive.
- */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
@@ -56,3 +77,4 @@ public class FindCommand extends Command {
                 .toString();
     }
 }
+**/

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -6,17 +6,20 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonQuery;
 
+/**
+ * Lists all clients from the address book based on {@code PersonQuery}
+ */
 public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
     public static final String MESSAGE_USAGE = "<TO BE ADDED>";
-    public static final String MESSAGE_SUCCESS = "<TO BE ADDED>";
 
     private final PersonQuery query;
 
+    /**
+     * @param query details for filtering clients
+     */
     public FindCommand(PersonQuery query) {
         requireNonNull(query);
         this.query = query;
@@ -26,31 +29,6 @@ public class FindCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         model.updateFilteredPersonList(query::filter);
-        return new CommandResult(MESSAGE_SUCCESS);
-    }
-}
-
-
-/**
-public class FindCommand extends Command {
-
-    public static final String COMMAND_WORD = "find";
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
-
-    private final NameContainsKeywordsPredicate predicate;
-
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
-        this.predicate = predicate;
-    }
-
-    @Override
-    public CommandResult execute(Model model) {
-        requireNonNull(model);
-        model.updateFilteredPersonList(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }
@@ -67,14 +45,11 @@ public class FindCommand extends Command {
         }
 
         FindCommand otherFindCommand = (FindCommand) other;
-        return predicate.equals(otherFindCommand.predicate);
+        return query.equals(otherFindCommand.query);
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this)
-                .add("predicate", predicate)
-                .toString();
+        return query.toString(new ToStringBuilder(this));
     }
 }
-**/

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,29 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
+import java.util.Set;
 
+import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.FindCommand;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RANK;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonQuery;
+import seedu.address.model.person.Phone;
+import seedu.address.model.rank.Rank;
+import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -19,15 +36,43 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        /*
+         * Even though all fields in {@code FindCommand} are optional,
+         * the command should expect at least one field. If the user
+         * want to list all clients without filters, please use {@code ListCommand} instead.
+        */
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                        PREFIX_ADDRESS, PREFIX_TAG, PREFIX_RANK);
+        // No trailing preamble
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    FindCommand.MESSAGE_USAGE));
         }
-
-        String[] nameKeywords = trimmedArgs.split("\\s+");
-
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        PersonQuery query = new PersonQuery();
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+            query.setName(name);
+        }
+        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+            query.setPhone(phone);
+        }
+        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+            query.setEmail(email);
+        }
+        if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
+            Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+            query.setAddress(address);
+        }
+        var tags = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        query.setTags(tags);
+        if (argMultimap.getValue(PREFIX_RANK).isPresent()) {
+            Rank rank = ParserUtil.parseRank(argMultimap.getValue(PREFIX_RANK).orElse(Rank.NO_RANK));
+            query.setRank(rank);
+        }
+        return new FindCommand(query);
     }
-
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -2,29 +2,21 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Set;
-
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.FindCommand;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RANK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonQuery;
 import seedu.address.model.person.Phone;
 import seedu.address.model.rank.Rank;
-import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new FindCommand object

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Set;
 
 import seedu.address.logic.commands.AddCommand;
@@ -45,33 +46,42 @@ public class FindCommandParser implements Parser<FindCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                         PREFIX_ADDRESS, PREFIX_TAG, PREFIX_RANK);
+        // No duplicate fields
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                PREFIX_ADDRESS, PREFIX_RANK);
         // No trailing preamble
         if (!argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     FindCommand.MESSAGE_USAGE));
         }
-        PersonQuery query = new PersonQuery();
+        PersonQuery query = PersonQuery.build();
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-            query.setName(name);
+            String trimmedArgs = name.toString().trim();
+            if (trimmedArgs.isEmpty()) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            }
+            String[] nameKeywords = trimmedArgs.split("\\s+");
+            query = query.setName(nameKeywords);
         }
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
             Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
-            query.setPhone(phone);
+            query = query.setPhone(phone);
         }
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
             Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
-            query.setEmail(email);
+            query = query.setEmail(email);
         }
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
             Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
-            query.setAddress(address);
+            query = query.setAddress(address);
         }
         var tags = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         query.setTags(tags);
         if (argMultimap.getValue(PREFIX_RANK).isPresent()) {
             Rank rank = ParserUtil.parseRank(argMultimap.getValue(PREFIX_RANK).orElse(Rank.NO_RANK));
-            query.setRank(rank);
+            query = query.setRank(rank);
         }
         return new FindCommand(query);
     }

--- a/src/main/java/seedu/address/model/person/PersonQuery.java
+++ b/src/main/java/seedu/address/model/person/PersonQuery.java
@@ -1,13 +1,12 @@
 package seedu.address.model.person;
 
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.rank.Rank;
@@ -21,7 +20,7 @@ import seedu.address.model.tag.Tag;
 public class PersonQuery {
 
     // Identity fields
-    private Optional<Name> name;
+    private Optional<Set<Name>> name;
     private Optional<Phone> phone;
     private Optional<Email> email;
 
@@ -33,14 +32,15 @@ public class PersonQuery {
     /**
      * Represents empty query
      */
-    public PersonQuery() {
+    private PersonQuery() {
         this(null, null, null, null, new HashSet<>(), null);
     }
+
     /**
      * Building person query at once
      */
-    public PersonQuery(Name name, Phone phone, Email email, Address address, Set<Tag> tags, Rank rank) {
-        this.name = Optional.ofNullable(name);
+    public PersonQuery(String[] args, Phone phone, Email email, Address address, Set<Tag> tags, Rank rank) {
+        setName(args);
         this.phone = Optional.ofNullable(phone);
         this.email = Optional.ofNullable(email);
         this.address = Optional.ofNullable(address);
@@ -48,28 +48,69 @@ public class PersonQuery {
         this.rank = Optional.ofNullable(rank);
     }
 
-    public void setName(Name name) {
-        this.name = Optional.of(name);
+    /**
+     * A default factory method to create PersonQuery object
+     */
+    public static PersonQuery build() {
+        return new PersonQuery();
     }
 
-    public void setPhone(Phone phone) {
+    /**
+     * @param args array of string of names to be filtered
+     * @return reference to itself (for chaining)
+     */
+    public PersonQuery setName(String[] args) {
+        if (args == null) {
+            this.name = Optional.empty();
+        } else {
+            Set<Name> nameSet = Arrays.stream(args)
+                    .map(s -> s.trim().toLowerCase())
+                    .map(Name::new)
+                    .collect(Collectors.toSet());
+            this.name = Optional.ofNullable(nameSet);
+        }
+        return this;
+    }
+
+    /**
+     * @param args array of {@code Name} to be filtered
+     * @return reference to itself (for chaining)
+     */
+    public PersonQuery setName(Name[] args) {
+        if (args == null) {
+            this.name = Optional.empty();
+        } else {
+            Set<Name> nameSet = Arrays.stream(args)
+                    .map(name -> new Name(name.toString().toLowerCase()))
+                    .collect(Collectors.toSet());
+            this.name = Optional.ofNullable(nameSet);
+        }
+        return this;
+    }
+
+    public PersonQuery setPhone(Phone phone) {
         this.phone = Optional.of(phone);
+        return this;
     }
 
-    public void setEmail(Email email) {
+    public PersonQuery setEmail(Email email) {
         this.email = Optional.of(email);
+        return this;
     }
 
-    public void setAddress(Address address) {
+    public PersonQuery setAddress(Address address) {
         this.address = Optional.of(address);
+        return this;
     }
 
-    public void setRank(Rank rank) {
+    public PersonQuery setRank(Rank rank) {
         this.rank = Optional.of(rank);
+        return this;
     }
 
-    public void setTags(Set<Tag> tags) {
+    public PersonQuery setTags(Set<Tag> tags) {
         this.tags.ifPresent(existingTags -> existingTags.addAll(tags));
+        return this;
     }
 
     /**
@@ -84,7 +125,16 @@ public class PersonQuery {
      * @return true if the person corresponds to the given query addressed above.
      */
     public boolean filter(Person person) {
-        boolean isCorrectName = this.name.filter(name -> !person.getName().equals(name)).isEmpty();
+
+        boolean isCorrectName = this.name.filter(name -> {
+            Set<Name> nameKeyword = Arrays.stream(person.getName().toString().trim().split("\\s+"))
+                    .map(s -> s.trim().toLowerCase())
+                    .map(Name::new)
+                    .collect(Collectors.toSet());
+            return Collections.disjoint(name, nameKeyword);
+        }).isEmpty();
+        // TODO: Relax the condition for phone number, address, and email
+        // TODO: Decouple the logic
         boolean isCorrectPhone = this.phone.filter(phone -> !person.getPhone().equals(phone)).isEmpty();
         boolean isCorrectAddress = this.address.filter(address -> !person.getAddress().equals(address)).isEmpty();
         boolean isCorrectEmail = this.email.filter(email -> !person.getEmail().equals(email)).isEmpty();
@@ -92,6 +142,19 @@ public class PersonQuery {
         boolean isCorrectTags = this.tags.filter(tags -> !person.getTags().containsAll(tags)).isEmpty();
         return isCorrectName && isCorrectPhone && isCorrectAddress && isCorrectEmail && isCorrectRank
                 && isCorrectTags;
+    }
+
+    /**
+     * Chain the string with {@code ToStringBuilder} object
+     */
+    public String toString(ToStringBuilder builder) {
+        this.name.ifPresent(n -> builder.add("name", n));
+        this.phone.ifPresent(p -> builder.add("phone", p));
+        this.email.ifPresent(e -> builder.add("email", e));
+        this.address.ifPresent(a -> builder.add("address", a));
+        this.tags.ifPresent(t -> builder.add("tags", t));
+        this.rank.ifPresent(r -> builder.add("rank", r));
+        return builder.toString();
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/PersonQuery.java
+++ b/src/main/java/seedu/address/model/person/PersonQuery.java
@@ -1,0 +1,126 @@
+package seedu.address.model.person;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.rank.Rank;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Represents a query object to find Person in the address book.
+ * Guarantees: Field values are validated.
+ * Remark: Details can be null and mutable.
+ */
+public class PersonQuery {
+
+    // Identity fields
+    private Optional<Name> name;
+    private Optional<Phone> phone;
+    private Optional<Email> email;
+
+    // Data fields
+    private Optional<Address> address;
+    private final Optional<Set<Tag>> tags = Optional.of(new HashSet<>());
+    private Optional<Rank> rank;
+
+    /**
+     * Represents empty query
+     */
+    public PersonQuery() {
+        this(null, null, null, null, new HashSet<>(), null);
+    }
+    /**
+     * Building person query at once
+     */
+    public PersonQuery(Name name, Phone phone, Email email, Address address, Set<Tag> tags, Rank rank) {
+        this.name = Optional.ofNullable(name);
+        this.phone = Optional.ofNullable(phone);
+        this.email = Optional.ofNullable(email);
+        this.address = Optional.ofNullable(address);
+        this.tags.ifPresent(existingTags -> existingTags.addAll(tags));
+        this.rank = Optional.ofNullable(rank);
+    }
+
+    public void setName(Name name) {
+        this.name = Optional.of(name);
+    }
+
+    public void setPhone(Phone phone) {
+        this.phone = Optional.of(phone);
+    }
+
+    public void setEmail(Email email) {
+        this.email = Optional.of(email);
+    }
+
+    public void setAddress(Address address) {
+        this.address = Optional.of(address);
+    }
+
+    public void setRank(Rank rank) {
+        this.rank = Optional.of(rank);
+    }
+
+    public void setTags(Set<Tag> tags) {
+        this.tags.ifPresent(existingTags -> existingTags.addAll(tags));
+    }
+
+    /**
+     * A predicate function of type {@code Predicate<Person>} to filter persons in a collection (such as lists).
+     * This function checks whether {@code Person} object follows the query given in {@code PersonQuery} object.
+     * {@code Person} must satisfy all fields (e.g. {@code this.name}, {#code this.email}, ...)
+     * in order for this function to return true.
+     * <br/>
+     * If {@code this.[FIELD]} is Nullable, {@code isCorrect[FIELD]} must always return true.
+     *
+     * @param person {@code Person} object to check
+     * @return true if the person corresponds to the given query addressed above.
+     */
+    public boolean filter(Person person) {
+        boolean isCorrectName = this.name.filter(name -> !person.getName().equals(name)).isEmpty();
+        boolean isCorrectPhone = this.phone.filter(phone -> !person.getPhone().equals(phone)).isEmpty();
+        boolean isCorrectAddress = this.address.filter(address -> !person.getAddress().equals(address)).isEmpty();
+        boolean isCorrectEmail = this.email.filter(email -> !person.getEmail().equals(email)).isEmpty();
+        boolean isCorrectRank = this.rank.filter(rank -> !person.getRank().equals(rank)).isEmpty();
+        boolean isCorrectTags = this.tags.filter(tags -> !person.getTags().containsAll(tags)).isEmpty();
+        return isCorrectName && isCorrectPhone && isCorrectAddress && isCorrectEmail && isCorrectRank
+                && isCorrectTags;
+    }
+
+    /**
+     * Returns true if both persons have the same identity and data fields.
+     * This defines a stronger notion of equality between two persons.
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof PersonQuery)) {
+            return false;
+        }
+
+        PersonQuery otherPerson = (PersonQuery) other;
+        return name.equals(otherPerson.name)
+                && phone.equals(otherPerson.phone)
+                && email.equals(otherPerson.email)
+                && address.equals(otherPerson.address)
+                && tags.equals(otherPerson.tags)
+                && rank.equals(otherPerson.rank);
+    }
+
+    @Override
+    public int hashCode() {
+        // use this method for custom fields hashing instead of implementing your own
+        return Objects.hash(name, phone, email, address, tags, rank);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -4,21 +4,31 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_RANK_STABLE;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import javafx.collections.ObservableList;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonQuery;
+import seedu.address.model.person.Phone;
+import seedu.address.model.rank.Rank;
+import seedu.address.model.tag.Tag;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -29,19 +39,17 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        PersonQuery firstQuery = PersonQuery.build().setName(new String[]{"first"});
+        PersonQuery secondQuery = PersonQuery.build().setName(new String[]{"second"});
 
-        FindCommand findFirstCommand = new FindCommand(firstPredicate);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate);
+        FindCommand findFirstCommand = new FindCommand(firstQuery);
+        FindCommand findSecondCommand = new FindCommand(secondQuery);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate);
+        FindCommand findFirstCommandCopy = new FindCommand(firstQuery);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
@@ -55,37 +63,62 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
+    public void execute_emptyQuery_showAllPersons() {
+        ObservableList<Person> originalList = expectedModel.getFilteredPersonList();
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, originalList.size());
+        PersonQuery emptyQuery = PersonQuery.build();
+        FindCommand command = new FindCommand(emptyQuery);
+        expectedModel.updateFilteredPersonList(emptyQuery::filter);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
     }
 
     @Test
-    public void execute_multipleKeywords_multiplePersonsFound() {
+    public void execute_multipleNames_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
+        PersonQuery query = PersonQuery.build().setName(new String[]{"Kurz", "Elle", "Kunz"});
+        FindCommand command = new FindCommand(query);
+        expectedModel.updateFilteredPersonList(query::filter);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
     }
 
     @Test
-    public void toStringMethod() {
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"));
-        FindCommand findCommand = new FindCommand(predicate);
-        String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
-        assertEquals(expected, findCommand.toString());
+    public void execute_phoneNumber_aliceFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        PersonQuery query = PersonQuery.build().setPhone(new Phone("94351253"));
+        FindCommand command = new FindCommand(query);
+        expectedModel.updateFilteredPersonList(query::filter);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE), model.getFilteredPersonList());
     }
 
-    /**
-     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
-     */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    @Test
+    public void execute_address_aliceFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        PersonQuery query = PersonQuery.build().setAddress(new Address("123, Jurong West Ave 6, #08-111"));
+        FindCommand command = new FindCommand(query);
+        expectedModel.updateFilteredPersonList(query::filter);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_singleTag_multipleFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        PersonQuery query = PersonQuery.build().setTags(Set.of(new Tag("friends")));
+        FindCommand command = new FindCommand(query);
+        expectedModel.updateFilteredPersonList(query::filter);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, DANIEL), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_rank_multipleFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 4);
+        PersonQuery query = PersonQuery.build().setRank(new Rank(VALID_RANK_STABLE));
+        FindCommand command = new FindCommand(query);
+        expectedModel.updateFilteredPersonList(query::filter);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, CARL, DANIEL), model.getFilteredPersonList());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,8 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.util.Arrays;
 import java.util.List;
@@ -23,11 +23,12 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonQuery;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
+import seedu.address.testutil.TypicalIndexes;
 
 public class AddressBookParserTest {
 
@@ -49,8 +50,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+                DeleteCommand.COMMAND_WORD + " " + TypicalIndexes.INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON), command);
     }
 
     @Test
@@ -58,8 +59,9 @@ public class AddressBookParserTest {
         Person person = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+                + TypicalIndexes.INDEX_FIRST_PERSON.getOneBased() + " "
+                + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+        assertEquals(new EditCommand(TypicalIndexes.INDEX_FIRST_PERSON, descriptor), command);
     }
 
     @Test
@@ -72,8 +74,13 @@ public class AddressBookParserTest {
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+                FindCommand.COMMAND_WORD + " " + PREFIX_NAME + " "
+                    + keywords.stream().collect(Collectors.joining(" "))
+        );
+        assertEquals(
+                new FindCommand(PersonQuery.build().setName(keywords.toArray(new String[0]))),
+                command
+        );
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,34 +1,111 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.RANK_DESC_STABLE;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_RANK_STABLE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
-import java.util.Arrays;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.PersonQuery;
+import seedu.address.model.person.Phone;
+import seedu.address.model.rank.Rank;
+import seedu.address.model.tag.Tag;
 
 public class FindCommandParserTest {
 
     private FindCommandParser parser = new FindCommandParser();
 
     @Test
-    public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    public void parse_emptyArg_success() {
+        String userInput = "    ";
+        FindCommand expectedFindCommand = new FindCommand(PersonQuery.build());
+        assertParseSuccess(parser, userInput, expectedFindCommand);
+    }
+
+    // Parse some field shows success
+    @Test
+    public void parse_someFields_success() {
+        String userInput = EMAIL_DESC_AMY;
+        userInput += RANK_DESC_STABLE;
+        FindCommand expectedFindCommand =
+                new FindCommand(PersonQuery.build()
+                        .setEmail(new Email(VALID_EMAIL_AMY))
+                        .setRank(new Rank(VALID_RANK_STABLE)));
+        assertParseSuccess(parser, userInput, expectedFindCommand);
+    }
+
+    // Parse all fields shows success
+    @Test
+    public void parse_allFields_success() {
+        String userInput = NAME_DESC_AMY + " " + VALID_NAME_BOB;
+        userInput += PHONE_DESC_AMY;
+        userInput += ADDRESS_DESC_AMY;
+        userInput += EMAIL_DESC_AMY;
+        userInput += TAG_DESC_FRIEND;
+        userInput += RANK_DESC_STABLE;
+        String trimmedArgs = (VALID_NAME_AMY + " " + VALID_NAME_BOB).trim();
+        String[] targetName = trimmedArgs.split("\\s+");
+        FindCommand expectedFindCommand =
+                new FindCommand(PersonQuery.build().setName(targetName)
+                        .setPhone(new Phone(VALID_PHONE_AMY))
+                        .setAddress(new Address(VALID_ADDRESS_AMY))
+                        .setEmail(new Email(VALID_EMAIL_AMY))
+                        .setTags(Set.of(new Tag(VALID_TAG_FRIEND)))
+                        .setRank(new Rank(VALID_RANK_STABLE)));
+        assertParseSuccess(parser, userInput, expectedFindCommand);
     }
 
     @Test
-    public void parse_validArgs_returnsFindCommand() {
-        // no leading and trailing whitespaces
-        FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+    public void parse_multipleRepeatedFields_failure() {
+        // valid followed by invalid
+        String userInput = INVALID_PHONE_DESC + PHONE_DESC_BOB;
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
-        // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        // invalid followed by valid
+        userInput = PHONE_DESC_BOB + INVALID_PHONE_DESC;
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+
+        // multiple valid fields repeated
+        userInput = PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
+                + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
+                + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
+
+        assertParseFailure(parser, userInput,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
+
+        // multiple invalid values
+        userInput = INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC
+                + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC;
+
+        assertParseFailure(parser, userInput,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
     }
-
 }

--- a/src/test/java/seedu/address/model/person/PersonQueryTest.java
+++ b/src/test/java/seedu/address/model/person/PersonQueryTest.java
@@ -1,25 +1,18 @@
 package seedu.address.model.person;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.Test;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-import static seedu.address.testutil.Assert.assertThrows;
-import seedu.address.testutil.PersonBuilder;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
+
+import org.junit.jupiter.api.Test;
 
 public class PersonQueryTest {
 
     @Test
     public void equals() {
-        PersonQuery aliceQuery = new PersonQuery();
-        PersonQuery bobQuery = new PersonQuery();
+        PersonQuery aliceQuery = PersonQuery.build();
+        PersonQuery bobQuery = PersonQuery.build();
 
         // comparing empty queries -> returns true
         assertTrue(aliceQuery.equals(bobQuery));
@@ -39,38 +32,28 @@ public class PersonQueryTest {
         assertFalse(aliceQuery.equals(5));
 
         // different name -> returns false
-        aliceQuery = (new PersonQuery());
-        aliceQuery.setName(ALICE.getName());
-        bobQuery = new PersonQuery();
-        bobQuery.setName(BOB.getName());
+        aliceQuery = PersonQuery.build().setName(new Name[]{ALICE.getName()});
+        bobQuery = PersonQuery.build().setName(new Name[]{BOB.getName()});
         assertFalse(aliceQuery.equals(bobQuery));
 
         // different phone -> returns false
-        aliceQuery = (new PersonQuery());
-        aliceQuery.setPhone(ALICE.getPhone());
-        bobQuery = new PersonQuery();
-        bobQuery.setPhone(BOB.getPhone());
+        aliceQuery = PersonQuery.build().setPhone(ALICE.getPhone());
+        bobQuery = PersonQuery.build().setPhone(BOB.getPhone());
         assertFalse(aliceQuery.equals(bobQuery));
 
         // different email -> returns false
-        aliceQuery = (new PersonQuery());
-        aliceQuery.setEmail(ALICE.getEmail());
-        bobQuery = new PersonQuery();
-        bobQuery.setEmail(BOB.getEmail());
+        aliceQuery = PersonQuery.build().setEmail(ALICE.getEmail());
+        bobQuery = PersonQuery.build().setEmail(BOB.getEmail());
         assertFalse(aliceQuery.equals(bobQuery));
 
         // different address -> returns false
-        aliceQuery = (new PersonQuery());
-        aliceQuery.setAddress(ALICE.getAddress());
-        bobQuery = new PersonQuery();
-        bobQuery.setAddress(BOB.getAddress());
+        aliceQuery = PersonQuery.build().setAddress(ALICE.getAddress());
+        bobQuery = PersonQuery.build().setAddress(BOB.getAddress());
         assertFalse(aliceQuery.equals(bobQuery));
 
         // different tags -> returns false
-        aliceQuery = (new PersonQuery());
-        aliceQuery.setTags(ALICE.getTags());
-        bobQuery = new PersonQuery();
-        bobQuery.setTags(BOB.getTags());
+        aliceQuery = PersonQuery.build().setTags(ALICE.getTags());
+        bobQuery = PersonQuery.build().setTags(BOB.getTags());
         assertFalse(aliceQuery.equals(bobQuery));
     }
 }

--- a/src/test/java/seedu/address/model/person/PersonQueryTest.java
+++ b/src/test/java/seedu/address/model/person/PersonQueryTest.java
@@ -3,11 +3,104 @@ package seedu.address.model.person;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.AMY;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
 import org.junit.jupiter.api.Test;
 
 public class PersonQueryTest {
+
+    @Test
+    public void filter_empty_expectTrue() {
+        assertTrue(PersonQuery.build().filter(ALICE));
+    }
+
+    @Test
+    public void filter_byName() {
+        PersonQuery query = PersonQuery
+                .build()
+                .setName(new String[]{"Pauline", "Doe"});
+        assertTrue(query.filter(ALICE));
+        assertFalse(query.filter(BOB));
+    }
+
+    @Test
+    public void filter_byPhone() {
+        PersonQuery query = PersonQuery
+            .build()
+            .setPhone(ALICE.getPhone());
+        assertTrue(query.filter(ALICE));
+        assertFalse(query.filter(BOB));
+    }
+
+    @Test
+    public void filter_byAddress() {
+        PersonQuery query = PersonQuery
+            .build()
+            .setAddress(ALICE.getAddress());
+        assertTrue(query.filter(ALICE));
+        assertFalse(query.filter(BOB));
+    }
+
+    @Test
+    public void filter_byEmail() {
+        PersonQuery query = PersonQuery
+            .build()
+            .setEmail(ALICE.getEmail());
+        assertTrue(query.filter(ALICE));
+        assertFalse(query.filter(BOB));
+    }
+
+    @Test
+    public void filter_bySingleTag() {
+        PersonQuery query = PersonQuery
+            .build()
+            .setTags(ALICE.getTags());
+        // ALICE tag (friends) is a subset of BENSON tag (owesMoney, friends)
+        assertTrue(query.filter(ALICE));
+        assertTrue(query.filter(BENSON));
+    }
+
+    @Test
+    public void filter_byMultipleTags() {
+        PersonQuery query = PersonQuery
+            .build()
+            .setTags(BENSON.getTags());
+        // ALICE tag (friends) is a subset of BENSON tag (owesMoney, friends)
+        assertFalse(query.filter(ALICE));
+        assertTrue(query.filter(BENSON));
+    }
+
+    @Test
+    public void filter_byRank() {
+        PersonQuery query = PersonQuery
+            .build()
+            .setRank(BOB.getRank());
+        assertTrue(query.filter(ALICE));
+        assertTrue(query.filter(BOB));
+        assertFalse(query.filter(AMY));
+    }
+
+    @Test
+    public void filter_chain_expectTrue() {
+        PersonQuery query = PersonQuery
+            .build()
+            .setRank(ALICE.getRank())
+            .setPhone(ALICE.getPhone());
+        assertTrue(query.filter(ALICE));
+        assertFalse(query.filter(BOB));
+    }
+
+    @Test
+    public void filter_chain_expectFalse() {
+        PersonQuery query = PersonQuery
+            .build()
+            .setName(new Name[]{ALICE.getName()})
+            .setPhone(BOB.getPhone());
+        assertFalse(query.filter(ALICE));
+        assertFalse(query.filter(BOB));
+    }
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/model/person/PersonQueryTest.java
+++ b/src/test/java/seedu/address/model/person/PersonQueryTest.java
@@ -1,0 +1,76 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.testutil.Assert.assertThrows;
+import seedu.address.testutil.PersonBuilder;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BOB;
+
+public class PersonQueryTest {
+
+    @Test
+    public void equals() {
+        PersonQuery aliceQuery = new PersonQuery();
+        PersonQuery bobQuery = new PersonQuery();
+
+        // comparing empty queries -> returns true
+        assertTrue(aliceQuery.equals(bobQuery));
+
+        // same values -> returns true
+        aliceQuery.setAddress(ALICE.getAddress());
+        bobQuery.setAddress(ALICE.getAddress());
+        assertTrue(aliceQuery.equals(bobQuery));
+
+        // same object -> returns true
+        assertTrue(bobQuery.equals(bobQuery));
+
+        // null -> returns false
+        assertFalse(aliceQuery.equals(null));
+
+        // different type -> returns false
+        assertFalse(aliceQuery.equals(5));
+
+        // different name -> returns false
+        aliceQuery = (new PersonQuery());
+        aliceQuery.setName(ALICE.getName());
+        bobQuery = new PersonQuery();
+        bobQuery.setName(BOB.getName());
+        assertFalse(aliceQuery.equals(bobQuery));
+
+        // different phone -> returns false
+        aliceQuery = (new PersonQuery());
+        aliceQuery.setPhone(ALICE.getPhone());
+        bobQuery = new PersonQuery();
+        bobQuery.setPhone(BOB.getPhone());
+        assertFalse(aliceQuery.equals(bobQuery));
+
+        // different email -> returns false
+        aliceQuery = (new PersonQuery());
+        aliceQuery.setEmail(ALICE.getEmail());
+        bobQuery = new PersonQuery();
+        bobQuery.setEmail(BOB.getEmail());
+        assertFalse(aliceQuery.equals(bobQuery));
+
+        // different address -> returns false
+        aliceQuery = (new PersonQuery());
+        aliceQuery.setAddress(ALICE.getAddress());
+        bobQuery = new PersonQuery();
+        bobQuery.setAddress(BOB.getAddress());
+        assertFalse(aliceQuery.equals(bobQuery));
+
+        // different tags -> returns false
+        aliceQuery = (new PersonQuery());
+        aliceQuery.setTags(ALICE.getTags());
+        bobQuery = new PersonQuery();
+        bobQuery.setTags(BOB.getTags());
+        assertFalse(aliceQuery.equals(bobQuery));
+    }
+}


### PR DESCRIPTION
Fixes #38 



### Checklist
- [x] Add `PersonQuery` to provide a structured query input.
- [x] Write test for `PersonQuery`. 
- [x] Support for chained commands
- [x] Edit `FindCommandParser` to filter based on multiple fields.
- [x] Write test for`FindCommandParser` to filter based on multiple fields.
- [x] Edit `FindCommand`
- [x] Write test for `FindCommand`
- [x] Update user guide (including `MESSAGE_USAGE`)

### Additional Checklist (that could be resolved in v1.3 milestone)
- Filter by appointment dates (wait for https://github.com/AY2526S1-CS2103T-T09-1/tp/pull/69 first)
- Relax constraints for matching email, address, and phone number. (e.g. matching phone number starts with 8123)

### Potential refactoring
- Decouple filtering logic for each fields in `PersonQuery` 

### Demo

https://github.com/user-attachments/assets/2b9cdb02-e230-40f0-87d7-762778c9924c

