### PR TITLE
Update error message for link

### DIFF
--- a/src/main/java/seedu/address/logic/commands/LinkAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LinkAppointmentCommand.java
@@ -50,10 +50,10 @@ public abstract class LinkAppointmentCommand extends Command {
             + "Example:\n"
             + MESSAGE_ADD_APPOINTMENT + "\n"
             + MESSAGE_EDIT_APPOINTMENT;
-    public static final String INCLUDE_FLAG = "Please include a flag after command. \n"
-            + "i.e. link -c [PARAMETERS], "
-            + "link -d [PARAMETERS], "
-            + "link -e [PARAMETERS]";
+    public static final String MESSAGE_INCLUDE_FLAG = "Please include a flag after command. \n"
+            + "i.e. To create an appointment: link -c [PARAMETERS], "
+            + "to delete an appointment: link -d [PARAMETERS], "
+            + "to edit an appointment: link -e [PARAMETERS]";
     public static final String MESSAGE_SUCCESS = "New appointment linked to %1$s: %2$s";
     public static final String MESSAGE_NO_SUCH_PERSON = "No client found with the name: %1$s";
     public static final String MESSAGE_DUPLICATE_APPOINTMENTS = "This appointment already exists in the address book.";

--- a/src/main/java/seedu/address/logic/commands/LinkAppointmentCreateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LinkAppointmentCreateCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LENGTH;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MESSAGE;

--- a/src/main/java/seedu/address/logic/commands/LinkAppointmentDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LinkAppointmentDeleteCommand.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+
 import java.util.Optional;
 
 import javafx.collections.ObservableList;
@@ -10,15 +12,6 @@ import seedu.address.model.appointment.Appointment;
 import seedu.address.model.appointment.AppointmentId;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
-
-import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_LENGTH;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_MESSAGE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
 /**
  * Edits an appointment and links it directly to a client (person).

--- a/src/main/java/seedu/address/logic/commands/LinkAppointmentEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LinkAppointmentEditCommand.java
@@ -1,5 +1,14 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LENGTH;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MESSAGE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
+
 import java.util.Objects;
 import java.util.Optional;
 
@@ -19,15 +28,6 @@ import seedu.address.model.appointment.AppointmentStatus;
 import seedu.address.model.appointment.AppointmentType;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
-
-import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_LENGTH;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_MESSAGE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
 /**
  * Edits an appointment and links it directly to a client (person).

--- a/src/main/java/seedu/address/logic/parser/LinkAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LinkAppointmentCommandParser.java
@@ -38,25 +38,32 @@ public class LinkAppointmentCommandParser implements Parser<LinkAppointmentComma
 
     @Override
     public LinkAppointmentCommand parse(String args) throws ParseException {
-        Appointment appointment;
-        Name clientName;
-        LinkAppointmentEditCommand.EditAppointmentDescriptor editAppointmentDescriptor =
-                new LinkAppointmentEditCommand.EditAppointmentDescriptor();
-
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args,
                         PREFIX_FLAG, PREFIX_ID, PREFIX_NAME, PREFIX_APPOINTMENT, PREFIX_LENGTH,
                         PREFIX_LOCATION, PREFIX_TYPE, PREFIX_MESSAGE, PREFIX_STATUS);
 
-        if (args.trim().isEmpty() || !argMultimap.getValue(PREFIX_FLAG).isPresent()) {
+        if (args.trim().isEmpty()
+                || argMultimap.getValue(PREFIX_FLAG).isEmpty()
+                || argMultimap.getValue(PREFIX_FLAG).get().split(" ")[0].length() != 1) {
+            //if flag is empty, or if flag has more than 1 character
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    LinkAppointmentCommand.INCLUDE_FLAG));
+                    LinkAppointmentCommand.MESSAGE_INCLUDE_FLAG));
         }
 
         validateCommand(argMultimap);
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ID, PREFIX_NAME, PREFIX_APPOINTMENT,
                 PREFIX_LENGTH, PREFIX_LOCATION, PREFIX_TYPE, PREFIX_MESSAGE, PREFIX_STATUS);
+
+        return returnCommand(argMultimap);
+    }
+
+    private LinkAppointmentCommand returnCommand(ArgumentMultimap argMultimap) throws ParseException {
+        Appointment appointment;
+        Name clientName;
+        LinkAppointmentEditCommand.EditAppointmentDescriptor editAppointmentDescriptor =
+                new LinkAppointmentEditCommand.EditAppointmentDescriptor();
 
         AppointmentFlag flag = ParserUtil.parseAppointmentFlag(argMultimap.getValue(PREFIX_FLAG).get());
 
@@ -108,7 +115,13 @@ public class LinkAppointmentCommandParser implements Parser<LinkAppointmentComma
     }
 
     private void validateCommand(ArgumentMultimap argMultimap) throws ParseException {
-        AppointmentFlag flag = ParserUtil.parseAppointmentFlag(argMultimap.getValue(PREFIX_FLAG).get());
+        AppointmentFlag flag =
+                ParserUtil.parseAppointmentFlag(
+                        argMultimap.getValue(PREFIX_FLAG).get().split(" ")[0]);
+        /*
+        if there is more than 1 word for flag, it would only take first, and it's guaranteed to be 1 digit due to
+        previous check.
+        */
         switch (flag.value) {
         case 'c':
             if (!arePrefixesPresent(argMultimap, PREFIX_FLAG, PREFIX_NAME, PREFIX_APPOINTMENT)
@@ -133,7 +146,7 @@ public class LinkAppointmentCommandParser implements Parser<LinkAppointmentComma
             break;
         default:
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    LinkAppointmentCommand.INCLUDE_FLAG));
+                    LinkAppointmentCommand.MESSAGE_INCLUDE_FLAG));
         }
     }
 

--- a/src/test/java/seedu/address/logic/parser/LinkAppointmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/LinkAppointmentCommandParserTest.java
@@ -33,7 +33,6 @@ import static seedu.address.testutil.TypicalPersons.BOB;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.LinkAppointmentCommand;
 import seedu.address.logic.commands.LinkAppointmentCreateCommand;
 import seedu.address.logic.commands.LinkAppointmentEditCommand.EditAppointmentDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -78,21 +77,22 @@ public class LinkAppointmentCommandParserTest {
     @Test
     public void parse_compulsoryFieldsMissing_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                LinkAppointmentCommand.MESSAGE_USAGE);
+                LinkAppointmentCreateCommand.MESSAGE_FAIL);
+
         // missing name prefix
-        assertParseFailure(parser, VALID_NAME_BOB + APPOINTMENT_DATE_TIME_DESC_BOB,
+        assertParseFailure(parser, " -c " + VALID_NAME_BOB + APPOINTMENT_DATE_TIME_DESC_BOB,
                 expectedMessage);
 
         // missing appointment prefix
-        assertParseFailure(parser, NAME_DESC_BOB + VALID_APPOINTMENT_DATE_TIME,
+        assertParseFailure(parser, " -c " + NAME_DESC_BOB + VALID_APPOINTMENT_DATE_TIME,
                 expectedMessage);
 
         // all prefixes missing
-        assertParseFailure(parser, VALID_NAME_BOB + VALID_APPOINTMENT_DATE_TIME,
+        assertParseFailure(parser, " -c " + VALID_NAME_BOB + VALID_APPOINTMENT_DATE_TIME,
                 expectedMessage);
 
         // Missing appointment timing
-        assertParseFailure(parser, NAME_DESC_BOB,
+        assertParseFailure(parser, " -c " + NAME_DESC_BOB,
                 expectedMessage);
     }
 


### PR DESCRIPTION
Fixes #113 

Changes made:
1) `link` will prompt users to include a flag
2) `link -FLAG` will give users the intended error message
3) Fixed error message issue on `link -c test`, where the tag name/ is not present.