### PR TITLE
`LinkAppointmentEditCommand`: Remove `[n/Name]` from error message.

### DIFF
--- a/src/main/java/seedu/address/logic/commands/LinkAppointmentEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LinkAppointmentEditCommand.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LENGTH;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MESSAGE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 


### PR DESCRIPTION

fix: #185 
Change this to sync with UG.

<img width="802" height="321" alt="Screenshot 2025-10-28 at 5 48 15 PM" src="https://github.com/user-attachments/assets/71c7d9fd-867e-4c93-9ea0-fa806c4e8d00" />
